### PR TITLE
[Refactor] Removed unnecessary call after AM update & fixed timezone offset

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -9,7 +9,12 @@ export function getDateFormatted(time: number): string {
   return `${year}-${month}-${day}`;
 }
 
+// Default behavior in JS if a timezone is behind GMT, then it has a positive
+// offset, but if it's ahead, it has a negative offset.
+// E.g. UTC-8 has an offset of 480 mins, but UTC+2 will be offset by -120 mins
+//
+// Marvin expects a negative offset (which is logical)
+// for timezones that are behind UTC and positive for ones that are ahead
 export function getMarvinTimezoneOffset(date = new Date()): number {
-  // Note: Marvin inverts the sign if it's behind GMT
   return -date.getTimezoneOffset()
 }

--- a/src/habitsToTaskRouter.ts
+++ b/src/habitsToTaskRouter.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import axios from 'axios';
 import { UNASSIGNED_PARENT_ID, MarvinEndpoint } from '../lib/constants';
-import { getDateFormatted } from '../lib/utils';
+import { getDateFormatted, getMarvinTimezoneOffset } from '../lib/utils';
 
 const router = express.Router();
 
@@ -14,8 +14,7 @@ router.post('/habit-as-task', async (req, res) => {
 
     // Convert Unix timestamp to YYYY-MM-DD format
     const recordedDate = getDateFormatted(record.time)
-    // Need timezone offset for accurate recording
-    const timeZoneOffset = new Date().getTimezoneOffset();
+    const timeZoneOffset = getMarvinTimezoneOffset()
 
     const createTaskData = {
       done: true,
@@ -23,7 +22,6 @@ router.post('/habit-as-task', async (req, res) => {
       timeEstimate,
       title,
       parentId,
-      // TO-DO: Handle case for when client and server aren't on same timezone
       timeZoneOffset
     };
 
@@ -31,7 +29,7 @@ router.post('/habit-as-task', async (req, res) => {
 
     console.log(`Successfully added done task for habit with name ${title}`)
     res.status(200).json({ message: `Successfully added done task for habit with name ${title}` });
-  } catch (error) {
+  } catch (error) { 
     console.error(error);
     res.status(500).send('An error occurred');
   }

--- a/src/habitsToTaskRouter.ts
+++ b/src/habitsToTaskRouter.ts
@@ -18,7 +18,6 @@ router.post('/habit-as-task', async (req, res) => {
     const timeZoneOffset = new Date().getTimezoneOffset();
 
     const createTaskData = {
-      // TO-DO: Known issue - "done: true" doesn't mark the task as done
       done: true,
       day: recordedDate,
       timeEstimate,
@@ -28,15 +27,10 @@ router.post('/habit-as-task', async (req, res) => {
       timeZoneOffset
     };
 
-    // (1) Create a task for the habit
-    const createTaskResponse = await axios.post(MarvinEndpoint.ADD_TASK, createTaskData);
+    await axios.post(MarvinEndpoint.ADD_TASK, createTaskData);
 
-    // (2) Mark created task as done
-    const createdTask = createTaskResponse.data
-    await axios.post(MarvinEndpoint.MARK_DONE, { itemId: createdTask._id, timeZoneOffset })
-
-    console.log(`Successfully created and marked done for task for habit with name ${title}`)
-    res.status(200).json({ message: `Successfully created and marked done for task for habit with name ${title}` });
+    console.log(`Successfully added done task for habit with name ${title}`)
+    res.status(200).json({ message: `Successfully added done task for habit with name ${title}` });
   } catch (error) {
     console.error(error);
     res.status(500).send('An error occurred');


### PR DESCRIPTION
## Summary

**What does this change do?**

**Change 1:**
- Previously, Amazing Marvin required two calls to make a finished task. One creating the task and one marking it as done
  - See: https://github.com/amazingmarvin/MarvinAPI/issues/54
- However, after the Amazing Marvin API updated, we can create tasks as "Done" directly

**Change 2:**
- Tasks done in the morning, e.g. "Morning skincare" would not work due to the timezone offset being flipped, so it would subtract instead of adding the offset. This has been corrected, by adding a negative sign

## Testing
**Automated Testing:** None as of yet
**Manual Testing:**
1. Tried with a test habit, it created a done task directly
2. The morning tasks, which were not being recorded correctly, are now being recorded correctly as expected