### PR TITLE
[Feature] Add marking habit as done when a task is complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ web_modules/
 .env.test.local
 .env.production.local
 .env.local
+.env*
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "runtimeArgs": [
+        "-r",
+        "ts-node/register"
+      ],
+      "args": [
+        "${workspaceFolder}/src/index.ts"
+      ]
+    }
+  ]
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -4,4 +4,8 @@ export const UNASSIGNED_PARENT_ID = 'unassigned'
 export const MarvinEndpoint = {
   ADD_TASK: `${API_BASE_URL}/addTask`,
   MARK_DONE: `${API_BASE_URL}/markDone`,
+  UPDATE_HABIT: `${API_BASE_URL}/updateHabit`,
+  LIST_HABITS_FULL: `${API_BASE_URL}/habits?raw=1`,
+  LIST_GOALS: `${API_BASE_URL}/goals`,
+  UPDATE_DOC: `${API_BASE_URL}/doc/update`,
 }

--- a/src/habitsToTaskRouter.ts
+++ b/src/habitsToTaskRouter.ts
@@ -9,6 +9,7 @@ router.post('/habit-as-task', async (req, res) => {
   try {
     switch (req.query.type) {
       case 'record-habit': await addTaskOnHabitCompletion(req.body, res); break
+      case 'mark-done': await markHabitOnTaskCompletion(req.body, res); break
     }
   } catch (error) { 
     console.error(error);
@@ -40,7 +41,55 @@ async function addTaskOnHabitCompletion(recordedHabitInfo, res) {
     console.log(`Successfully added done task for habit with name ${title}`)
     res.status(200).json({ message: `Successfully added done task for habit with name ${title}` });
 }
+
+async function markHabitOnTaskCompletion(completedTaskInfo, res) {
+  const { title } = completedTaskInfo
+
+  // List all the habits
+  const { data: habitInfos } = await axios.get(MarvinEndpoint.LIST_HABITS_FULL);
+
+  // Build a mapping of habit IDs and to which words to map to
+  const habitIdToPatternMatchingMap = buildHabitToPatternsMapping(habitInfos)
+
+  // TO-DO: Refactor this using a filter
+  // Go through each pattern, check if any of the titles match
+  const habitIdsToMarkComplete = []
+  for (const [habitId, patterns] of Object.entries(habitIdToPatternMatchingMap)) {
+    if (patterns.some(pattern => title.toLowerCase().includes(pattern))) habitIdsToMarkComplete.push(habitId)
   }
-});
+
+  // No tasks to mark complete
+  if (habitIdsToMarkComplete.length === 0) {
+    console.log(`No related habits to mark done for task ${title}`)
+    return res.status(200).json({ message: `No related habits to mark done for task ${title}` });
+  }
+
+  // Otherwise, go through and mark all the matched habits as complete
+  await Promise.all(habitIdsToMarkComplete.map(habitId => {
+    return axios.post(MarvinEndpoint.UPDATE_HABIT, getRecordHabitData(habitId))
+  }))
+
+  console.log(`Successfully marked habits with IDs ${habitIdsToMarkComplete.join(', ')} complete for ${title}`)
+  res.status(200).json({ message: `Successfully added done task for habit with name ${title}` });
+}
+function buildHabitToPatternsMapping(habitInfos) {
+  const habitToPatternsMapping: Record<string, string[]> = {}
+  for (const { _id, note } of habitInfos) {
+    if (note.length === 0) continue
+
+    const patterns = note.split(CSV_REGEX).map(s => s.toLowerCase())
+    habitToPatternsMapping[_id] = patterns
+  }
+  return habitToPatternsMapping
+}
+
+function getRecordHabitData(habitId) {
+  return {
+    habitId,
+    time: Date.now(),
+    value: 1,
+    updateDB: true,
+  }
+}
 
 export default router;

--- a/src/habitsToTaskRouter.ts
+++ b/src/habitsToTaskRouter.ts
@@ -7,7 +7,17 @@ const router = express.Router();
 
 router.post('/habit-as-task', async (req, res) => {
   try {
-    const { parentId, timeEstimate, title, record } = req.body
+    switch (req.query.type) {
+      case 'record-habit': await addTaskOnHabitCompletion(req.body, res); break
+    }
+  } catch (error) { 
+    console.error(error);
+    res.status(500).send('An error occurred');
+  }
+});
+
+async function addTaskOnHabitCompletion(recordedHabitInfo, res) {
+  const { parentId, timeEstimate, title, record } = recordedHabitInfo
     if (parentId === UNASSIGNED_PARENT_ID) {
       return res.status(200).json({ message: `Skipping creating a task for habit with name ${title}` })
     }
@@ -29,9 +39,7 @@ router.post('/habit-as-task', async (req, res) => {
 
     console.log(`Successfully added done task for habit with name ${title}`)
     res.status(200).json({ message: `Successfully added done task for habit with name ${title}` });
-  } catch (error) { 
-    console.error(error);
-    res.status(500).send('An error occurred');
+}
   }
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ dotenv.config();
 
 // Send API token each time to Marvin
 axios.defaults.headers.common['X-API-Token'] = process.env.MARVIN_API_TOKEN;
+axios.defaults.headers.common['X-Full-Access-Token'] = process.env.MARVIN_FULL_ACCESS_TOKEN;
 
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
## Summary
**Feature:** Mark habits as done if a matching task was completed!
When the user **completes** a task - the automatic habit recording is performed based off rules that the user adds in the note. For example, if I do a task "Do flashcards" then it will automatically mark off my habit "Do Japanese flashcards."

There are also a few minor changes:
- Added a debugger config for VS Code so you're not prompted to make one
- Added a `.gitignore` for `.env` files - I'm now using multiple `.env`'s and before it was only ignoring `.env` specifically
- Refactors the previous `addTaskForHabit` code into a switch statement to make it easier to add more endpoints later on

## Testing
This is how you would use this flow:
1. Go to the Habits screen. This is achieved by pressing "H"
2. Right click and click "Edit note"
![image](https://github.com/user-attachments/assets/71a6e42f-9c01-431a-840c-606acbf7f48a)
3. After clicking "Edit note", you can add a CSV list of patterns to match.
![image](https://github.com/user-attachments/assets/97708d29-a24f-4dff-a659-170a6ae85875)

After adding this, whenever a task is completed with any of these terms `["do flashcards", "reviews", "review cards", "flashcards"]` (case insensitive), then this will automatically mark the habit as done