### PR TITLE
[Fetaure] Automatically assign goals to tasks

### DIFF
--- a/src/habitsToTaskRouter.ts
+++ b/src/habitsToTaskRouter.ts
@@ -4,12 +4,14 @@ import { UNASSIGNED_PARENT_ID, MarvinEndpoint } from '../lib/constants';
 import { getDateFormatted, getMarvinTimezoneOffset } from '../lib/utils';
 
 const router = express.Router();
+const CSV_REGEX = /\s*,\s*/
 
 router.post('/habit-as-task', async (req, res) => {
   try {
     switch (req.query.type) {
       case 'record-habit': await addTaskOnHabitCompletion(req.body, res); break
       case 'mark-done': await markHabitOnTaskCompletion(req.body, res); break
+      case 'add-task': await assignGoalToTask(req.body, res); break
     }
   } catch (error) { 
     console.error(error);
@@ -19,27 +21,27 @@ router.post('/habit-as-task', async (req, res) => {
 
 async function addTaskOnHabitCompletion(recordedHabitInfo, res) {
   const { parentId, timeEstimate, title, record } = recordedHabitInfo
-    if (parentId === UNASSIGNED_PARENT_ID) {
-      return res.status(200).json({ message: `Skipping creating a task for habit with name ${title}` })
-    }
+  if (parentId === UNASSIGNED_PARENT_ID) {
+    return res.status(200).json({ message: `Skipping creating a task for habit with name ${title}` })
+  }
 
-    // Convert Unix timestamp to YYYY-MM-DD format
-    const recordedDate = getDateFormatted(record.time)
-    const timeZoneOffset = getMarvinTimezoneOffset()
+  // Convert Unix timestamp to YYYY-MM-DD format
+  const recordedDate = getDateFormatted(record.time)
+  const timeZoneOffset = getMarvinTimezoneOffset()
 
-    const createTaskData = {
-      done: true,
-      day: recordedDate,
-      timeEstimate,
-      title,
-      parentId,
-      timeZoneOffset
-    };
+  const createTaskData = {
+    done: true,
+    day: recordedDate,
+    timeEstimate,
+    title,
+    parentId,
+    timeZoneOffset
+  };
 
-    await axios.post(MarvinEndpoint.ADD_TASK, createTaskData);
+  await axios.post(MarvinEndpoint.ADD_TASK, createTaskData);
 
-    console.log(`Successfully added done task for habit with name ${title}`)
-    res.status(200).json({ message: `Successfully added done task for habit with name ${title}` });
+  console.log(`Successfully added done task for habit with name ${title}`)
+  res.status(200).json({ message: `Successfully added done task for habit with name ${title}` });
 }
 
 async function markHabitOnTaskCompletion(completedTaskInfo, res) {
@@ -72,6 +74,47 @@ async function markHabitOnTaskCompletion(completedTaskInfo, res) {
   console.log(`Successfully marked habits with IDs ${habitIdsToMarkComplete.join(', ')} complete for ${title}`)
   res.status(200).json({ message: `Successfully added done task for habit with name ${title}` });
 }
+
+async function assignGoalToTask(completedTaskInfo, res) {
+  const { title, _id: taskId } = completedTaskInfo
+
+  // List all the goals
+  const { data: goalInfos } = await axios.get(MarvinEndpoint.LIST_GOALS);
+
+  // Build a mapping of goal IDs and to which words to map to
+  const goalIdToPatternsMapping = buildHabitToPatternsMapping(goalInfos)
+
+  // Goal ID to attach
+  let goalIdToAttach = null
+  for (const [goalId, patterns] of Object.entries(goalIdToPatternsMapping)) {
+    if (patterns.some(pattern => title.toLowerCase().includes(pattern))) {
+      goalIdToAttach = goalId
+    }
+  }
+
+  // No goal to attach to, skipping
+  if (goalIdToAttach === null) {
+    console.log(`No related goals to mark done for task ${title}`)
+    return res.status(200).json({ message: `No related goals to mark done for task ${title}` });
+  }
+
+  // Update task with goal
+  const updateTaskData = {
+    itemId: taskId,
+    setters: [
+      { key: `g_in_${goalIdToAttach}`, val: true },
+      { key: `fieldUpdates.g_in_${goalIdToAttach}`, val: Date.now() },
+      { key: 'updatedAt', val: Date.now() },
+    ]
+  }
+
+  // Update the task with the goal ID
+  await axios.post(MarvinEndpoint.UPDATE_DOC, updateTaskData)
+
+  console.log(`Assigned goal ${goalIdToAttach} to task with name ${title}`)
+  res.status(200).json({ message: `Assigned goal ${goalIdToAttach} to habit with name ${title}` });
+}
+
 function buildHabitToPatternsMapping(habitInfos) {
   const habitToPatternsMapping: Record<string, string[]> = {}
   for (const { _id, note } of habitInfos) {


### PR DESCRIPTION
## Summary
**What does this change do?**
Similar to #9  - when a new task is created, we check the Goal note, and if the task name matches any of the search patterns, we automatically assign it that goal. We assume there is only one goal ID for a given matching search term and we will pick the first one that matches in the order that Amazing Marvin provides it to us.

The next PR will likely be to add more automations of this style, e.g. automatically adding a category or pattern matching it to a saved task to save time for adding tasks.

## Testing
See [video](https://drive.google.com/file/d/1Y6yt6c3izUSc7Zyi02F9pHMjmqn7X_mr/view?usp=sharing)
This video mocks a new UI adding goal <-> habit <-> task integration, but the idea is you can get edit the goal note and do the same matching as #9 