### PR TITLE
Bug fix: Whitespace in notes not parsed correctly

### DIFF
--- a/src/habitsToTaskRouter.ts
+++ b/src/habitsToTaskRouter.ts
@@ -7,6 +7,9 @@ import logger from '../lib/logger'
 const router = express.Router();
 const CSV_REGEX = /\s*,\s*/
 
+// Need this as \n\n\\\ is padded for each empty line on note 
+const MARVIN_WHITESPACE_REGEX = /[\n\\]+$/g
+
 router.post('/habit-as-task', async (req, res) => {
   try {
     switch (req.query.type) {
@@ -119,9 +122,9 @@ async function assignGoalToTask(completedTaskInfo, res) {
 function buildHabitToPatternsMapping(habitInfos) {
   const habitToPatternsMapping: Record<string, string[]> = {}
   for (const { _id, note } of habitInfos) {
-    if (note.length === 0) continue
+    if (note == null || note.length === 0) continue
 
-    const patterns = note.split(CSV_REGEX).map(s => s.toLowerCase())
+    const patterns = note.split(CSV_REGEX).map(s => s.toLowerCase().replace(MARVIN_WHITESPACE_REGEX, ''))
     habitToPatternsMapping[_id] = patterns
   }
   return habitToPatternsMapping


### PR DESCRIPTION
## Summary
Here is how the metadata in the note is set up in my Marvin:
```
Eat a bowl of broccoli, Eat a salad

```
Note that there's was some whitespace trailing after these CSVs. As a result, what would happen is the program would internally parse it as the following:
```
2|marvin-automation  | [
2|marvin-automation  |   'Eat a bowl of broccoli',
2|marvin-automation  |   'Eat a salad\n\n\\\n\\\n\\'
2|marvin-automation  | ]
```
However, the `\n\n\\\` pad at the end makes it so that "eat a salad" never matches the above string and therefore, a habit is never marked for that task.

After fixing it, this is what it's parsed as (which is correct) and correctly matches the task:
```
2|marvin-automation  | [
2|marvin-automation  |   'Eat a bowl of broccoli',
2|marvin-automation  |   'Eat a salad'
2|marvin-automation  | ]
```

## Testing
**Manual testing:**
Tested this manually by testing the completion of the same task before and after. Before, it would not count the task against the habit. Now, it is counted against the habit/it marks it off