### PR TITLE
Add habit note directive to skip task creation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,6 @@
 #Your API Token here
 MARVIN_API_TOKEN=
+#Your Full Access Token here (only required for direct doc reads/updates)
+MARVIN_FULL_ACCESS_TOKEN=
 #HTTP Server port (to receive webhooks) e.g. 80, 443, or 3000
 PORT=

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ npm install
 - Rename the file named `.env.template` to `.env`
 - Get your API key: go to Amazing Marvin on web/desktop > Strategies (press S) > API (beta) > Settings > View credentials > Copy paste the value under "API token"
 - Paste this value onto the empty spot where it says `MARVIN_API_TOKEN`
+- Optional: paste the value under "Full access token" into `MARVIN_FULL_ACCESS_TOKEN` if you need direct document reads/updates through Marvin's `/api/doc` endpoints
 
 (4) Set up Amazing Marvin webhooks
 - Go to API settings in Amazing Marvin (see instructions in #3)
@@ -67,6 +68,8 @@ If you run into any issues, need help, or have any feature suggestions for this 
 
   - Allows users to customize the task created after recording a habit.
   - Example: Recording the habit "Brush teeth in the morning" creates a task "Brush teeth #Self-Care ~10m +Today".
+  - To stop a specific habit from creating completed tasks, add `$skipHabitTaskCreation` anywhere in that habit's note in Marvin.
+  - This is useful when a habit has a category for Marvin organization, but should not generate a task when recorded.
 </details>
 
 <details>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -2,6 +2,7 @@ export const API_BASE_URL = 'https://serv.amazingmarvin.com/api'
 export const TIMEZONE_OFFSET = (-8 * 60) // TO-DO: Make calculation dynamic based on client and server 
 export const UNASSIGNED_PARENT_ID = 'unassigned'
 export const NOTE_KEYWORD_SEPARATOR_REGEX = /\s*,\s*/
+export const SKIP_HABIT_TASK_CREATION_DIRECTIVE = '$skipHabitTaskCreation'
 
 // Marvin pads empty note lines with backslashes, which should not become keyword text.
 export const MARVIN_NOTE_TRAILING_PADDING_REGEX = /[\n\\]+$/g

--- a/lib/marvinTypes.ts
+++ b/lib/marvinTypes.ts
@@ -8,6 +8,7 @@ export interface HabitRecord {
 export interface RecordHabitWebhook {
   _id: string
   title: string
+  note?: string | null
   parentId: string
   timeEstimate?: number
   record: HabitRecord

--- a/src/habitsToTaskRouter.ts
+++ b/src/habitsToTaskRouter.ts
@@ -4,6 +4,7 @@ import type { Response } from 'express'
 import {
   MARVIN_NOTE_TRAILING_PADDING_REGEX,
   NOTE_KEYWORD_SEPARATOR_REGEX,
+  SKIP_HABIT_TASK_CREATION_DIRECTIVE,
   UNASSIGNED_PARENT_ID,
   MarvinEndpoint
 } from '../lib/constants'
@@ -46,6 +47,9 @@ async function addTaskOnHabitCompletion(recordedHabitInfo: RecordHabitWebhook, r
   const { parentId, timeEstimate, title, record } = recordedHabitInfo
   if (parentId === UNASSIGNED_PARENT_ID) {
     return res.status(200).json({ message: `Skipping creating a task for habit with name: ${title}` })
+  }
+  if (await shouldSkipHabitTaskCreation(recordedHabitInfo)) {
+    return res.status(200).json({ message: `Skipping creating a task for habit with skip directive: ${title}` })
   }
 
   // Convert Unix timestamp to YYYY-MM-DD format
@@ -153,6 +157,20 @@ function buildNoteKeywordMap(sources: NoteKeywordSource[]): Record<string, strin
   return noteKeywordMap
 }
 
+async function shouldSkipHabitTaskCreation(recordedHabitInfo: RecordHabitWebhook): Promise<boolean> {
+  const note = recordedHabitInfo.note ?? await getHabitNote(recordedHabitInfo._id)
+  return hasSkipHabitTaskCreationDirective(note)
+}
+
+async function getHabitNote(habitId: string): Promise<string | null | undefined> {
+  const { data: habitInfos } = await axios.get<NoteKeywordSource[]>(MarvinEndpoint.LIST_HABITS_FULL)
+  return habitInfos.find(habitInfo => habitInfo._id === habitId)?.note
+}
+
+function hasSkipHabitTaskCreationDirective(note: string | null | undefined): boolean {
+  return (note ?? '').toLowerCase().includes(SKIP_HABIT_TASK_CREATION_DIRECTIVE.toLowerCase())
+}
+
 function getRecordHabitData(habitId: string): RecordHabitPayload {
   return {
     habitId,
@@ -168,5 +186,7 @@ export {
   assignGoalToTask,
   buildNoteKeywordMap,
   getRecordHabitData,
-  markHabitOnTaskCompletion
+  hasSkipHabitTaskCreationDirective,
+  markHabitOnTaskCompletion,
+  shouldSkipHabitTaskCreation
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -51,6 +51,7 @@ describe('habit-as-task validation', () => {
       .send({
         _id: 'habit-1',
         title: 'Drink water',
+        note: '',
         parentId: 'project-1',
         timeEstimate: 300000,
         record: { time: recordTime, value: 1 },
@@ -82,6 +83,43 @@ describe('habit-as-task validation', () => {
     expect(axios.post).not.toHaveBeenCalled()
   })
 
+  test('skips creating a task when the webhook note has the skip directive', async () => {
+    const response = await request(buildApp())
+      .post('/habit-as-task?type=record-habit')
+      .send({
+        _id: 'habit-1',
+        title: 'Log Calories',
+        note: '$skipHabitTaskCreation',
+        parentId: 'project-1',
+        record: { time: new Date(2024, 0, 2).getTime(), value: 1 }
+      })
+
+    expect(response.status).toBe(200)
+    expect(response.body.message).toBe('Skipping creating a task for habit with skip directive: Log Calories')
+    expect(axios.get).not.toHaveBeenCalled()
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+
+  test('skips creating a task when the fetched habit note has the skip directive', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: [{ _id: 'habit-1', note: 'calorie keywords, $skipHabitTaskCreation' }]
+    })
+
+    const response = await request(buildApp())
+      .post('/habit-as-task?type=record-habit')
+      .send({
+        _id: 'habit-1',
+        title: 'Log Calories',
+        parentId: 'project-1',
+        record: { time: new Date(2024, 0, 2).getTime(), value: 1 }
+      })
+
+    expect(response.status).toBe(200)
+    expect(response.body.message).toBe('Skipping creating a task for habit with skip directive: Log Calories')
+    expect(axios.get).toHaveBeenCalledWith(MarvinEndpoint.LIST_HABITS_FULL)
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+
   test('preserves Marvin title whitespace instead of normalizing webhook data', async () => {
     axios.post.mockResolvedValueOnce({})
 
@@ -90,6 +128,7 @@ describe('habit-as-task validation', () => {
       .send({
         _id: 'habit-1',
         title: '  Drink water  ',
+        note: '',
         parentId: 'project-1',
         record: { time: new Date(2024, 0, 2).getTime(), value: 1 }
       })


### PR DESCRIPTION
## Summary
**What does this change do?**
Adds a Marvin-note directive that lets a habit opt out of creating a completed task when it is recorded.

Add `$skipHabitTaskCreation` anywhere in a habit note to skip task creation for that habit. This keeps the customization in Marvin, alongside the habit metadata, instead of requiring a server-side environment variable.

### (1) Major - Added note-based skip behavior
1. Checks record-habit webhook notes for `$skipHabitTaskCreation` before creating a completed task.
2. Falls back to fetching `habits?raw=1` and reading the habit note by ID when the webhook payload does not include a note.
3. Leaves existing unassigned-habit skipping behavior unchanged.

### (2) Minor - Documented configuration
4. Updated the README with the new note directive.
5. Added the optional full-access token field to the env template for direct Marvin doc reads/updates.

### (3) Minor - Added test coverage
6. Covered skipping from a webhook-provided note and from a fetched habit note.

## Testing
**Automated tests:**
- `npm test`
- `npm run typecheck`
- `npm run lint`

**Manual testing:**
Not run locally against a live Marvin account.