### PR TITLE
[Bug fix] Fix habit task completed time metadata + minor bug fixes/refactoring

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -32,10 +32,11 @@ function getUserLogFormat() {
   return winston.format.printf(info => {
     const now = new Date()
 
-    // Format the date in YYYY-MM-DD
-    const date = now.toISOString().split('T')[0]
-
-    // Format the time in locale-specific time string
+    // Format the local date in YYYY-MM-DD.
+    const year = now.getFullYear()
+    const month = String(now.getMonth() + 1).padStart(2, '0')
+    const day = String(now.getDate()).padStart(2, '0')
+    const date = `${year}-${month}-${day}`
     const time = now.toLocaleTimeString()
 
     // Get the timezone offset in the format UTC±HHMM

--- a/lib/marvinTypes.ts
+++ b/lib/marvinTypes.ts
@@ -26,6 +26,7 @@ export interface NoteKeywordSource {
 
 export interface CreateTaskPayload {
   done: true
+  doneAt: number
   day: string
   title: string
   parentId: string

--- a/src/habitsToTaskRouter.ts
+++ b/src/habitsToTaskRouter.ts
@@ -58,6 +58,7 @@ async function addTaskOnHabitCompletion(recordedHabitInfo: RecordHabitWebhook, r
 
   const createTaskData: CreateTaskPayload = {
     done: true,
+    doneAt: record.time,
     day: recordedDate,
     timeEstimate,
     title,

--- a/src/habitsToTaskRouter.ts
+++ b/src/habitsToTaskRouter.ts
@@ -48,7 +48,7 @@ async function addTaskOnHabitCompletion(recordedHabitInfo: RecordHabitWebhook, r
   if (parentId === UNASSIGNED_PARENT_ID) {
     return res.status(200).json({ message: `Skipping creating a task for habit with name: ${title}` })
   }
-  if (await shouldSkipHabitTaskCreation(recordedHabitInfo)) {
+  if (hasSkipHabitTaskCreationDirective(recordedHabitInfo.note)) {
     return res.status(200).json({ message: `Skipping creating a task for habit with skip directive: ${title}` })
   }
 
@@ -158,16 +158,6 @@ function buildNoteKeywordMap(sources: NoteKeywordSource[]): Record<string, strin
   return noteKeywordMap
 }
 
-async function shouldSkipHabitTaskCreation(recordedHabitInfo: RecordHabitWebhook): Promise<boolean> {
-  const note = recordedHabitInfo.note ?? await getHabitNote(recordedHabitInfo._id)
-  return hasSkipHabitTaskCreationDirective(note)
-}
-
-async function getHabitNote(habitId: string): Promise<string | null | undefined> {
-  const { data: habitInfos } = await axios.get<NoteKeywordSource[]>(MarvinEndpoint.LIST_HABITS_FULL)
-  return habitInfos.find(habitInfo => habitInfo._id === habitId)?.note
-}
-
 function hasSkipHabitTaskCreationDirective(note: string | null | undefined): boolean {
   return (note ?? '').toLowerCase().includes(SKIP_HABIT_TASK_CREATION_DIRECTIVE.toLowerCase())
 }
@@ -188,6 +178,5 @@ export {
   buildNoteKeywordMap,
   getRecordHabitData,
   hasSkipHabitTaskCreationDirective,
-  markHabitOnTaskCompletion,
-  shouldSkipHabitTaskCreation
+  markHabitOnTaskCompletion
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -61,11 +61,13 @@ describe('habit-as-task validation', () => {
     expect(response.status).toBe(200)
     expect(axios.post).toHaveBeenCalledWith(MarvinEndpoint.ADD_TASK, expect.objectContaining({
       done: true,
+      doneAt: recordTime,
       day: '2024-01-02',
       title: 'Drink water',
       parentId: 'project-1',
       timeEstimate: 300000
     }))
+    expect(axios.get).not.toHaveBeenCalled()
   })
 
   test('skips creating a task for unassigned habits', async () => {
@@ -100,10 +102,8 @@ describe('habit-as-task validation', () => {
     expect(axios.post).not.toHaveBeenCalled()
   })
 
-  test('skips creating a task when the fetched habit note has the skip directive', async () => {
-    axios.get.mockResolvedValueOnce({
-      data: [{ _id: 'habit-1', note: 'calorie keywords, $skipHabitTaskCreation' }]
-    })
+  test('does not fetch habits before creating a task when webhook note is omitted', async () => {
+    axios.post.mockResolvedValueOnce({})
 
     const response = await request(buildApp())
       .post('/habit-as-task?type=record-habit')
@@ -115,9 +115,12 @@ describe('habit-as-task validation', () => {
       })
 
     expect(response.status).toBe(200)
-    expect(response.body.message).toBe('Skipping creating a task for habit with skip directive: Log Calories')
-    expect(axios.get).toHaveBeenCalledWith(MarvinEndpoint.LIST_HABITS_FULL)
-    expect(axios.post).not.toHaveBeenCalled()
+    expect(axios.get).not.toHaveBeenCalled()
+    expect(axios.post).toHaveBeenCalledWith(MarvinEndpoint.ADD_TASK, expect.objectContaining({
+      done: true,
+      doneAt: new Date(2024, 0, 2).getTime(),
+      title: 'Log Calories'
+    }))
   })
 
   test('preserves Marvin title whitespace instead of normalizing webhook data', async () => {


### PR DESCRIPTION
## Summary
**What does this change do?**
Essentially, it looks like with Marvin's latest update to 1.70.0, they also changed the habit API behavior slightly. Before: this call succeeded and would create a done task with the done time set automatically. Now, it seems that the API explicitly requires this `doneAt` time parameter but it's not listed anywhere in the wiki, so this change was surprising

We added this and now the task is created at the right time. Otherwise, it'd add the habit to the very bottom of the task list (or to the very top - depending on the platform. Inconsistent behavior) which was very annoying

**Two other minor bug fixes:**
1. Refactors/simplifies the skip directive handling. Cuts one extra "get habits" API call
2. Minor logger issue - at night time in Pacific, it'd show the next day's date instead of today's date because it was calculating the date in UTC. Fixed it 

## Testing
Updated unit tests, but otherwise no automated E2E

**Manual testing:**
Pulled branch into prod, marked a few habits and then confirmed that adding `doneAt: record.time` makes habit-created tasks populate done-time metadata and sort correctly in the completed section

**Screenshot:**
<img width="664" alt="Animated demo" src="https://i.imgur.com/dEr1kUc.gif" />

The top one is the one created after this PR / set of commits, notice that it's created with the correct completion time